### PR TITLE
Add support for default options in commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 _..._
 
+## 1.1.0 - 2016-03-14
+
+- Added `defaultOptions` to the command interface and abstract
+
 ## 1.0.0 - 2016-01-05
 
 - Initial release

--- a/src/AbstractCommand.php
+++ b/src/AbstractCommand.php
@@ -24,6 +24,8 @@ abstract class AbstractCommand implements CommandInterface
             }
         }
 
+        $this->options += $this->defaultOptions();
+
         return $this->options;
     }
 
@@ -55,5 +57,13 @@ abstract class AbstractCommand implements CommandInterface
     public function hasOption($name)
     {
         return isset($this->options[$name]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function defaultOptions()
+    {
+        return [];
     }
 }

--- a/src/CommandInterface.php
+++ b/src/CommandInterface.php
@@ -50,6 +50,13 @@ interface CommandInterface
     public function requiredOptions();
 
     /**
+     * Get a hash of default options
+     *
+     * @return array
+     */
+    public function defaultOptions();
+
+    /**
      * Execute the command using the current options
      *
      * @return mixed

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -115,4 +115,23 @@ class CommandTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($output);
     }
+
+    public function testDefaultOptions()
+    {
+        $command = $this->getMockBuilder(AbstractCommand::class)
+            ->setMethods(['defaultOptions'])
+            ->getMockForAbstractClass();
+
+        $command
+            ->expects($this->once())
+            ->method('defaultOptions')
+            ->willReturn([
+                'test' => true,
+            ]);
+
+        $options = $command->options();
+
+        $this->assertArrayHasKey('test', $options);
+        $this->assertTrue($options['test']);
+    }
 }


### PR DESCRIPTION
Default options are commonly applied when an option is not required.
By baking this functionality into the command our code becomes simpler
and we can self-document options that can exist for a command.
