### PR TITLE
Add http status method to command exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 _..._
 
+## 1.2.0 - ???
+
+- Added `getHttpStatus` to command exception
+
 ## 1.1.0 - 2016-03-14
 
 - Added `defaultOptions` to the command interface and abstract

--- a/src/CommandException.php
+++ b/src/CommandException.php
@@ -6,7 +6,7 @@ use RuntimeException;
 
 class CommandException extends RuntimeException
 {
-    const MISSING_OPTION = 500;
+    const MISSING_OPTION = 2000;
 
     /**
      * @param string $name
@@ -19,5 +19,19 @@ class CommandException extends RuntimeException
             sprintf('Required option `%s` is not defined', $name),
             static::MISSING_OPTION
         );
+    }
+
+    /**
+     * Get the HTTP status for the exception.
+     *
+     * @return integer
+     */
+    public function getHttpStatus()
+    {
+        if ($this->getCode() === static::MISSING_OPTION) {
+            return 400;
+        }
+
+        return 500;
     }
 }

--- a/tests/CommandExceptionTest.php
+++ b/tests/CommandExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EquipTests\Command;
+
+use Equip\Command\CommandException;
+
+class CommandExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testMissingOption()
+    {
+        $exception = CommandException::missingOption('test');
+
+        $this->assertRegExp('/required option/i', $exception->getMessage());
+        $this->assertSame(CommandException::MISSING_OPTION, $exception->getCode());
+        $this->assertSame(400, $exception->getHttpStatus());
+    }
+
+    public function testDefaultHttpStatus()
+    {
+        $exception = new CommandException();
+
+        $this->assertSame(500, $exception->getHttpStatus());
+    }
+}

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -90,10 +90,6 @@ class CommandTest extends TestCase
         $this->assertArrayHasKey('user_id', $options);
     }
 
-    /**
-     * @expectedException \Equip\Command\CommandException
-     * @expectedExceptionCode \Equip\Command\CommandException::MISSING_OPTION
-     */
     public function testRequiredOptionsFailure()
     {
         $this->command
@@ -102,6 +98,12 @@ class CommandTest extends TestCase
             ->willReturn([
                 'user_id',
             ]);
+
+        $this->setExpectedException(
+            CommandException::class,
+            '',
+            CommandException::MISSING_OPTION
+        );
 
         $this->command->options();
     }


### PR DESCRIPTION
Also changes the missing option code to be more agnostic.
