### PR TITLE
Report all missing options at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _..._
 ## 1.2.0 - ???
 
 - Added `getHttpStatus` to command exception
+- Report all missing options at once with command exception
+- Deprecated `CommandException::missingOption` in favor of `missingOptions`
 
 ## 1.1.0 - 2016-03-14
 

--- a/src/AbstractCommand.php
+++ b/src/AbstractCommand.php
@@ -17,10 +17,9 @@ abstract class AbstractCommand implements CommandInterface
         $required = $this->requiredOptions();
 
         if ($required) {
-            foreach ($required as $key) {
-                if (!isset($this->options[$key])) {
-                    throw CommandException::missingOption($key);
-                }
+            $missing = array_diff($required, array_keys($this->options));
+            if ($missing) {
+                throw CommandException::missingOptions($missing);
             }
         }
 

--- a/src/CommandException.php
+++ b/src/CommandException.php
@@ -8,10 +8,27 @@ class CommandException extends RuntimeException
 {
     const MISSING_OPTION = 2000;
 
+    /*
+     * @param array $names
+     *
+     * @return static
+     *
+     * @since 1.2.0
+     */
+    public static function missingOptions(array $names)
+    {
+        return new static(
+            sprintf('Required options not defined: `%s`', implode('`, `', $names)),
+            static::MISSING_OPTION
+        );
+    }
+
     /**
      * @param string $name
      *
      * @return static
+     *
+     * @deprecated 1.2.0
      */
     public static function missingOption($name)
     {

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -97,11 +97,12 @@ class CommandTest extends TestCase
             ->method('requiredOptions')
             ->willReturn([
                 'user_id',
+                'article_id',
             ]);
 
-        $this->setExpectedException(
+        $this->setExpectedExceptionRegExp(
             CommandException::class,
-            '',
+            '/required options not defined.+user_id.+article_id/i',
             CommandException::MISSING_OPTION
         );
 


### PR DESCRIPTION
Reduces annoyance when failing to define multiple required options by
reporting all missing options in a single exception.
