### PR TITLE
Separate command and options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 _..._
 
+## 1.3.0 - 2016-04-05
+
+- Added `Command` and `Options` abstract classes
+- Deprecated `AbstractCommand` and `CommandInterface`
+
 ## 1.2.0 - 2016-03-22
 
 - Added `getHttpStatus` to command exception

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,113 @@
+Migrating
+=========
+
+Use this document to help you transition away from deprecated code.
+
+## Switching from AbstractCommand to Command
+
+Version 1.3.0 introduces a new `Command` class that replaces `AbstractCommand`.
+It also introduces a new, immutable `Options` class that is used to hold options
+for commands.
+
+### Updating Commands
+
+Commands that used to be defined as:
+
+```php
+use Equip\Command\AbstractCommand;
+
+class LoginCommand extends AbstractCommand
+{
+    // ...
+}
+```
+
+Should now be defined as:
+
+```php
+use Equip\Command\Command;
+
+class LoginCommand extends Command
+{
+    // ...
+}
+```
+
+This will also require modification in how commands use options internally.
+Previously the `execute()` method would access options as an array:
+
+```php
+public function execute()
+{
+    $options = $this->options();
+
+    $this->checkCredentials($options['email'], $options['password']);
+
+    // ...
+}
+```
+
+Instead, the options will now be a read-only object:
+
+```
+public function execute()
+{
+    $options = $this->options();
+
+    $this->checkCredentials($options->email, $options->password);
+
+    // ...
+}
+```
+
+Any attempt to modify the options will throw an `ImmutableException`.
+
+### Creating Options
+
+Command options are now defined as separate classes. These classes must extend
+the `Options` class:
+
+```php
+use Equip\Command\Options;
+
+final class LoginOptions extends Options
+{
+    protected $email;
+    protected $password;
+    protected $remember = false;
+
+    /**
+     * @inheritdoc
+     */
+    public function required()
+    {
+        return [
+            'email',
+            'password',
+        ];
+    }
+}
+```
+
+All valid options are defined as `protected` class properties. Optional properties
+can have default values.
+
+### Using Commands
+
+Where calling code would previously be:
+
+```php
+$command = $command->withOptions([
+    'email' => 'user@example.net',
+    'password' => 'very-secret',
+]);
+```
+
+The new options class must be used instead:
+
+```php
+$options = new LoginOptions([
+    'email' => 'user@example.com',
+    'password' => 'very-secret',
+]);
+$command = $command->withOptions($options);

--- a/src/AbstractCommand.php
+++ b/src/AbstractCommand.php
@@ -2,6 +2,9 @@
 
 namespace Equip\Command;
 
+/**
+ * @deprecated since 1.3.0 in favor of Command
+ */
 abstract class AbstractCommand implements CommandInterface
 {
     /**

--- a/src/Command.php
+++ b/src/Command.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Equip\Command;
+
+/**
+ * A general purpose command class.
+ *
+ * @since 1.3.0
+ */
+abstract class Command
+{
+    /**
+     * @var OptionsInterface
+     */
+    private $options;
+
+    /**
+     * Execute the command using the current options.
+     *
+     * @return mixed
+     */
+    abstract public function execute();
+
+    /**
+     * Allow usage as a callable.
+     *
+     * @see Command::execute()
+     *
+     * @return mixed
+     */
+    final public function __invoke()
+    {
+        return $this->execute();
+    }
+
+    /**
+     * Get the currently defined options.
+     *
+     * @return OptionsInterface
+     *
+     * @throws CommandException
+     *  If no options have been added to the command.
+     */
+    final public function options()
+    {
+        if (!$this->options) {
+            throw CommandException::needsOptions($this);
+        }
+
+        return $this->options;
+    }
+
+    /**
+     * Get a copy with new options.
+     *
+     * @param Options $options
+     *
+     * @return static
+     */
+    final public function withOptions(Options $options)
+    {
+        $copy = clone $this;
+        $copy->options = $options;
+
+        return $copy;
+    }
+}

--- a/src/CommandException.php
+++ b/src/CommandException.php
@@ -6,7 +6,23 @@ use RuntimeException;
 
 class CommandException extends RuntimeException
 {
+    const NO_OPTIONS = 2000;
     const MISSING_OPTION = 2000;
+
+    /**
+     * @param Command $command
+     *
+     * @return static
+     *
+     * @since 1.3.0
+     */
+    public static function needsOptions(Command $command)
+    {
+        return new static(sprintf(
+            'No options have been set for the `%s` command',
+            get_class($command)
+        ), static::NO_OPTIONS);
+    }
 
     /*
      * @param array $names

--- a/src/CommandInterface.php
+++ b/src/CommandInterface.php
@@ -2,6 +2,9 @@
 
 namespace Equip\Command;
 
+/**
+ * @deprecated since 1.3.0 in favor of Command
+ */
 interface CommandInterface
 {
     /**

--- a/src/ImmutableException.php
+++ b/src/ImmutableException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Equip\Command;
+
+use LogicException;
+
+class ImmutableException extends LogicException
+{
+    const CANNOT_MODIFY = 1;
+
+    /**
+     * @param object $object
+     *
+     * @return static
+     */
+    public static function cannotModify($object)
+    {
+        return new static(
+            sprintf(
+                'Object `%s` is immutable and cannot be modified',
+                get_class($object)
+            ),
+            static::CANNOT_MODIFY
+        );
+    }
+}

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Equip\Command;
+
+/**
+ * A general purpose value object for command options.
+ *
+ * When constructed, all required options must be passed.
+ *
+ * @since 1.3.0
+ */
+abstract class Options
+{
+    /**
+     * Check that all required options are defined, then hydrate.
+     *
+     * @param array $values
+     */
+    final public function __construct(array $values)
+    {
+        // Remove any values that are invalid for this set of options
+        $values = array_intersect_key(
+            $values,
+            array_flip($this->valid())
+        );
+
+        $this->ensureRequired($values);
+
+        foreach ($values as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+
+    /**
+     * Get a list of all required options.
+     *
+     *     return [
+     *         'email',
+     *         'password',
+     *     ];
+     *
+     * @return array
+     */
+    abstract public function required();
+
+    /**
+     * Get a list of all valid options.
+     *
+     * @return array
+     */
+    public function valid()
+    {
+        return array_keys($this->toArray());
+    }
+
+    /**
+     * Get all options as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return get_object_vars($this);
+    }
+
+    /**
+     * Provide read-only access to attributes.
+     *
+     * @param string $key
+     *
+     * @return mixed
+     */
+    final public function __get($key)
+    {
+        return $this->{$key};
+    }
+
+    /**
+     * Prevent modification.
+     *
+     * @throws ImmutableException
+     *
+     * @param string $key
+     * @param mixed $value
+     *
+     * @return void
+     */
+    final public function __set($key, $value)
+    {
+        throw ImmutableException::cannotModify($this);
+    }
+
+    /**
+     * Prevent modification.
+     *
+     * @throws ImmutableException
+     *
+     * @param string $key
+     *
+     * @return void
+     */
+    final public function __unset($key)
+    {
+        throw ImmutableException::cannotModify($this);
+    }
+
+    /**
+     * Ensure that all required options are included in the given values.
+     *
+     * @param array $values
+     *
+     * @return void
+     *
+     * @throws CommandException
+     *  If any required options have not been defined.
+     */
+    private function ensureRequired(array $values)
+    {
+        $defined = array_filter($values, static function ($value) {
+            return $value !== null;
+        });
+
+        $missing = array_diff($this->required(), array_keys($defined));
+
+        if ($missing) {
+            throw CommandException::missingOptions($missing);
+        }
+    }
+}

--- a/tests/AbstractCommandTest.php
+++ b/tests/AbstractCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Equip\Command;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class AbstractCommandTest extends TestCase
+{
+    /**
+     * @var AbstractCommand
+     */
+    private $command;
+
+    public function setUp()
+    {
+        $this->command = $this->getMockForAbstractClass(AbstractCommand::class);
+    }
+
+    public function testOptions()
+    {
+        $options = [
+            'user_id'    => 5,
+            'account_id' => 1,
+        ];
+
+        $this->assertEmpty($this->command->options());
+
+        // Copy the command and replace options
+        $command = $this->command->withOptions($options);
+
+        // Original command options should still be empty
+        $this->assertEmpty($this->command->options());
+
+        // The command should be copied
+        $this->assertNotSame($command, $this->command);
+
+        // And the options in the new command should match
+        $this->assertSame($options, $command->options());
+
+        $added = [
+            'start_time' => new \DateTime,
+        ];
+
+        // Copy the command and add options
+        $modified = $command->addOptions($added);
+
+        $this->assertNotSame($command, $modified);
+
+        // Options should be combined
+        $this->assertSame(array_replace($options, $added), $modified->options());
+
+        // Copy the command and replace options
+        $replaced = $command->withOptions($added);
+
+        // Options should be replaced
+        $this->assertSame($added, $replaced->options());
+    }
+
+    public function testHasOption()
+    {
+        $command = $this->command->withOptions([
+            'foo' => true,
+            'bar' => false,
+            'baz' => null,
+        ]);
+
+        // Empty values allowed
+        $this->assertTrue($command->hasOption('foo'));
+        $this->assertTrue($command->hasOption('bar'));
+        $this->assertFalse($command->hasOption('baz'));
+        $this->assertFalse($command->hasOption('fiz'));
+    }
+
+    public function testRequiredOptions()
+    {
+        $this->command
+            ->expects($this->once())
+            ->method('requiredOptions')
+            ->willReturn([
+                'user_id',
+            ]);
+
+        $command = $this->command->withOptions([
+            'user_id' => 0,
+            'okay'    => true,
+        ]);
+
+        $options = $command->options();
+
+        $this->assertArrayHasKey('user_id', $options);
+    }
+
+    public function testRequiredOptionsFailure()
+    {
+        $this->command
+            ->expects($this->once())
+            ->method('requiredOptions')
+            ->willReturn([
+                'user_id',
+                'article_id',
+            ]);
+
+        $this->setExpectedExceptionRegExp(
+            CommandException::class,
+            '/required options not defined.+user_id.+article_id/i',
+            CommandException::MISSING_OPTION
+        );
+
+        $this->command->options();
+    }
+
+    public function testExecute()
+    {
+        $this->command->method('execute')
+            ->willReturn(true);
+
+        $output = $this->command->execute();
+
+        $this->assertTrue($output);
+    }
+
+    public function testDefaultOptions()
+    {
+        $command = $this->getMockBuilder(AbstractCommand::class)
+            ->setMethods(['defaultOptions'])
+            ->getMockForAbstractClass();
+
+        $command
+            ->expects($this->once())
+            ->method('defaultOptions')
+            ->willReturn([
+                'test' => true,
+            ]);
+
+        $options = $command->options();
+
+        $this->assertArrayHasKey('test', $options);
+        $this->assertTrue($options['test']);
+    }
+}

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Equip\Command;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class OptionsTest extends TestCase
+{
+    public function testConstruction()
+    {
+        $values = [
+            'email' => 'test@example.com',
+            'password' => 'secret',
+        ];
+
+        $options = new TestedOptions($values);
+
+        $this->assertSame($values['email'], $options->email);
+        $this->assertSame($values['password'], $options->password);
+
+        $this->assertArraySubset($values, $options->toArray());
+    }
+
+    public function testMissing()
+    {
+        $this->setExpectedExceptionRegExp(
+            CommandException::class,
+            '/required options not defined/i',
+            CommandException::MISSING_OPTION
+        );
+
+        $options = new TestedOptions([]);
+    }
+
+    public function testMagicGet()
+    {
+        $values = [
+            'email' => 'test@example.com',
+            'password' => 'secret',
+        ];
+
+        $options = new TestedOptions($values);
+
+        $this->assertSame($values['email'], $options->email);
+        $this->assertSame($values['password'], $options->password);
+    }
+
+    public function testMagicSet()
+    {
+        $values = [
+            'email' => 'test@example.com',
+            'password' => 'secret',
+        ];
+
+        $options = new TestedOptions($values);
+
+        $this->setExpectedExceptionRegExp(
+            ImmutableException::class,
+            '/object .* is immutable/i',
+            ImmutableException::CANNOT_MODIFY
+        );
+
+        $options->email = 'fails';
+    }
+
+    public function testMagicUnset()
+    {
+        $values = [
+            'email' => 'test@example.com',
+            'password' => 'secret',
+        ];
+
+        $options = new TestedOptions($values);
+
+        $this->setExpectedExceptionRegExp(
+            ImmutableException::class,
+            '/object .* is immutable/i',
+            ImmutableException::CANNOT_MODIFY
+        );
+
+        unset($options->email);
+    }
+}

--- a/tests/TestedOptions.php
+++ b/tests/TestedOptions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Equip\Command;
+
+final class TestedOptions extends Options
+{
+    protected $email;
+    protected $password;
+    protected $first_name;
+    protected $last_name;
+
+    public function required()
+    {
+        return [
+            'email',
+            'password',
+        ];
+    }
+}


### PR DESCRIPTION
Having separate value objects for options makes it easier to understand
what options are available to a command and simplifies the validation
process.

This change was implemented as separate classes so that usage can be
upgraded incrementally and version 2.0 can remove the deprecated things.
