### PR TITLE
Remove serialization from options

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -11,9 +11,7 @@ command system that is flexible and can be used in modern and legacy environment
 
 ### Creating an Options Value Object
 
-All options must implement `OptionsInterface`, which includes the ability to
-serialize the value object to JSON. The `OptionsSerializerTrait` can provide
-this functionality.
+All options must implement `OptionsInterface`.
 
 Options must validate the values passed during construction. If you are using an
 array to hydrate the options, the `OptionsRequiredTrait` will help you validate
@@ -22,12 +20,10 @@ requirements. Type checking should also be done when suitable.
 ```php
 use Equip\Command\OptionsInterface;
 use Equip\Command\OptionsRequiredTrait;
-use Equip\Command\OptionsSerializerTrait;
 
 class LoginOptions implements OptionsInterface
 {
     use OptionsRequiredTrait;
-    use OptionsSerializerTrait;
 
     private $email;
     private $password;

--- a/src/OptionsInterface.php
+++ b/src/OptionsInterface.php
@@ -2,18 +2,16 @@
 
 namespace Equip\Command;
 
-use JsonSerializable;
-
 /**
  * Command options are value objects that cannot be modified once constructed.
  *
  * All options must self-validate during construction to ensure that internal
  * state is always valid.
  *
- * All options must be serializable to allow deferred command execution.
+ * All options should be serializable to allow deferred command execution.
  *
  * Option values should only be exposed by getter methods.
  */
-interface OptionsInterface extends JsonSerializable
+interface OptionsInterface
 {
 }


### PR DESCRIPTION
JSON specific serialization is typically not needed with options.
