### PR TITLE
Add trait to allow hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 _..._
 
-## 2.0.0 - ?
+## 2.0.0 - 2016-08-26
 ### Added
 
 - `CommandImmutableOptionsTrait` for copying commands when setting options
 - `OptionsInterface` for implementation of options as values objects
+- `OptionsHydrateTrait` for hydrating option properties
 - `OptionsSerializerTrait` for JSON serializing support for options
 - `OptionsRequiredTrait` for checking required values for options
 

--- a/src/OptionsHydrateTrait.php
+++ b/src/OptionsHydrateTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Equip\Command;
+
+/**
+ * Provides hydrating functionality for options.
+ */
+trait OptionsHydrateTrait
+{
+    /**
+     * Hydrate the current object with the given values.
+     *
+     * Values should be filtered beforehand so that only properties that exist
+     * in the object are passed.
+     *
+     * @param array $values
+     *
+     * @return void
+     */
+    private function hydrate(array $values)
+    {
+        foreach ($values as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+}

--- a/tests/OptionsHydrateTraitTest.php
+++ b/tests/OptionsHydrateTraitTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Equip\Command;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class OptionsHydrateTraitTest extends TestCase
+{
+    use OptionsHydrateTrait;
+
+    private $hydrated = false;
+
+    public function testHydrate()
+    {
+        $this->assertFalse($this->hydrated);
+
+        $this->hydrate([
+            'hydrated' => true,
+        ]);
+
+        $this->assertTrue($this->hydrated);
+    }
+}


### PR DESCRIPTION
Makes it easier to accept an array of values in the `__construct` of options.
