### PR TITLE
Fix checkRequired() to pass correct options to exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 _..._
 
+## 2.0.1 - 2016-08-29
+### Fixed
+- `OptionsRequiredTrait` to send the correct missing fields when throwing an exception
+
 ## 2.0.0 - 2016-08-26
 ### Added
 

--- a/src/OptionsRequiredTrait.php
+++ b/src/OptionsRequiredTrait.php
@@ -20,7 +20,7 @@ trait OptionsRequiredTrait
      */
     private function checkRequired(array $options, array $keys)
     {
-        $missing = array_diff_key(array_flip($keys), $options);
+        $missing = array_flip(array_diff_key(array_flip($keys), $options));
 
         if (!empty($missing)) {
             throw CommandException::missingOptions($missing);

--- a/src/OptionsRequiredTrait.php
+++ b/src/OptionsRequiredTrait.php
@@ -20,7 +20,7 @@ trait OptionsRequiredTrait
      */
     private function checkRequired(array $options, array $keys)
     {
-        $missing = array_flip(array_diff_key(array_flip($keys), $options));
+        $missing = array_keys(array_diff_key(array_flip($keys), $options));
 
         if (!empty($missing)) {
             throw CommandException::missingOptions($missing);

--- a/tests/OptionsRequiredTraitTest.php
+++ b/tests/OptionsRequiredTraitTest.php
@@ -23,7 +23,7 @@ class OptionsRequiredTraitTest extends TestCase
     {
         $this->setExpectedExceptionRegExp(
             CommandException::class,
-            '/required options/i',
+            '/required options.*test/i',
             CommandException::MISSING_OPTION
         );
 


### PR DESCRIPTION
The `missing` variable needs to be flipped again to pass the correct values to `CommandException`. Updated the test to validate this.
